### PR TITLE
Adjust display of the repository owner and name

### DIFF
--- a/components/RepositoryItemTopBar.tsx
+++ b/components/RepositoryItemTopBar.tsx
@@ -25,14 +25,15 @@ export const RepositoryItemTopBar = ({
         target="_blank"
         title={`Open ${repositoryOwner}/${repositoryName} on GitHub`}
       >
-        <div className="repo-item__name">
-          <h3>
-            {repositoryName}
-          </h3>
+        <h3>
           <div className="repo-item__owner">
-            &nbsp;/ {repositoryOwner}
+            {repositoryOwner}
           </div>
-        </div>
+          <span>&nbsp;/&nbsp;</span>
+          <div className="repo-item__name">
+            {repositoryName}
+          </div>
+        </h3>
       </a>
 
       <RepositoryIssueNumberIndicator

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -119,25 +119,19 @@ base, html {
   @media(min-width: 1012px) {
     margin-bottom: 32px;
   }
-}
-
-.repo-item__name {
-  display: flex;
-  color: #096BDE;
-  font-size: 16px;
-  line-height: 1.5;
 
   h3 {
+    display: flex;
+    color: #096BDE;
     font-size: 16px;
+    line-height: 1.5;
     font-weight: 400;
-  }
-  .repo-item__owner {
-    font-weight: 600;
-  }
 
-  @media(min-width: 1012px) {
-    font-size: 24px;
-    h3 {
+    .repo-item__name {
+      font-weight: 600;
+    }
+
+    @media(min-width: 1012px) {
       font-size: 24px;
     }
   }


### PR DESCRIPTION
Fixes https://github.com/github/forgoodfirstissue/issues/80

I'm 100% uncertain if the semantics of my changes are satisfactory, so I won't take any offense if you decide to redo this. 🤷🏻 

<img width="1429" alt="updated appearance" src="https://github.com/github/forgoodfirstissue/assets/417751/b87edf4a-d6a8-4394-b61e-04db16352d7e">

