### PR TITLE
Pin third party action in deploy.yml

### DIFF
--- a/.github/workflows/deploy.yml
+++ b/.github/workflows/deploy.yml
@@ -64,7 +64,7 @@ jobs:
         env:
           GH_PERSONAL_ACCESS_TOKEN: ${{ secrets.GH_PERSONAL_ACCESS_TOKEN }}
       - name: Update happycommits.json
-        uses: stefanzweifel/git-auto-commit-action@v4
+        uses: stefanzweifel/git-auto-commit-action@3ea6ae190baf489ba007f7c92608f33ce20ef04a #v4.16.0
         with:
           commit_message: update generated.json [skip actions]
           branch: deploy


### PR DESCRIPTION
<!-- If adding a project to For Good First Issue please uncomment and include the following: 

#### ℹ️ Repository information

**The repository**:

- [ ] Is a social good project.
 - Link:
- [ ] Is for a DPG (Digital Public Good) 
- [ ] The project has tags in in its description denoting which SDGs it addresses. ie `sdg-1`, `sdg-2`, etc.
- [ ] The project has a contributing file.
- [ ] The project has a code of conduct file.
- [ ] The project has a license.
- [ ] Actively maintained (last updated less than 1 months ago).
-->

This pull request pins the SHA for a third party action. The action `stefanzweifel/git-auto-commit-action` is now pinned to `3ea6ae190baf489ba007f7c92608f33ce20ef04a`.

