### PR TITLE
Prepare for next v14 by removing `@next/font`

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,7 +12,6 @@
         "@fortawesome/free-regular-svg-icons": "^6.4.2",
         "@fortawesome/free-solid-svg-icons": "^6.3.0",
         "@fortawesome/react-fontawesome": "^0.2.0",
-        "@next/font": "^14.2.5",
         "@primer/react-brand": "^0.27.1",
         "@types/node": "20.12.12",
         "@types/react": "18.2.56",
@@ -849,14 +848,6 @@
       "dev": true,
       "dependencies": {
         "glob": "7.1.7"
-      }
-    },
-    "node_modules/@next/font": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-14.2.5.tgz",
-      "integrity": "sha512-e2f3M+tAuJPUyXwWtEPKlPfpPEKODiQvPjdxOWBZC+zgdGv18KfjTkEmopfkfpZ016yCvw5BmMPeuEU/uiDf9g==",
-      "peerDependencies": {
-        "next": "*"
       }
     },
     "node_modules/@next/swc-darwin-arm64": {
@@ -7021,12 +7012,6 @@
       "requires": {
         "glob": "7.1.7"
       }
-    },
-    "@next/font": {
-      "version": "14.2.5",
-      "resolved": "https://registry.npmjs.org/@next/font/-/font-14.2.5.tgz",
-      "integrity": "sha512-e2f3M+tAuJPUyXwWtEPKlPfpPEKODiQvPjdxOWBZC+zgdGv18KfjTkEmopfkfpZ016yCvw5BmMPeuEU/uiDf9g==",
-      "requires": {}
     },
     "@next/swc-darwin-arm64": {
       "version": "13.4.9",

--- a/package.json
+++ b/package.json
@@ -15,7 +15,6 @@
     "@fortawesome/free-regular-svg-icons": "^6.4.2",
     "@fortawesome/free-solid-svg-icons": "^6.3.0",
     "@fortawesome/react-fontawesome": "^0.2.0",
-    "@next/font": "^14.2.5",
     "@primer/react-brand": "^0.27.1",
     "@types/node": "20.12.12",
     "@types/react": "18.2.56",


### PR DESCRIPTION
<!-- If adding a project to For Good First Issue please uncomment and include the following: 

#### ℹ️ Repository information

**The repository**:

- [ ] Is a social good project.
 - Link:
- [ ] Is for a DPG (Digital Public Good) 
- [ ] The project has tags in in its description denoting which SDGs it addresses. ie `sdg-1`, `sdg-2`, etc.
- [ ] The project has a contributing file.
- [ ] The project has a code of conduct file.
- [ ] The project has a license.
- [ ] Actively maintained (last updated less than 1 months ago).
-->

Based on the below warning

```
- warn Your project has `@next/font` installed as a dependency, please use the built-in `next/font` instead. The `@next/font` package will be removed in Next.js 14. You can migrate by running `npx @next/codemod@latest built-in-next-font .`. Read more: https://nextjs.org/docs/messages/built-in-next-font
```

this PR removes the `@next/font` package from the `package.json` file and replaces instances with the built-in `next/font`.
