### PR TITLE
Fix suggest project template

### DIFF
--- a/.github/ISSUE_TEMPLATE/suggest_project.yml
+++ b/.github/ISSUE_TEMPLATE/suggest_project.yml
@@ -31,7 +31,6 @@ body:
       options:
         - label: "Yes"
         - label: "No"
-          required: true
   - type: checkboxes
     id: SDGs
     attributes:


### PR DESCRIPTION
Remove obligatory for answer, forcing users to answer "No" to question "Is the Project a DPG?"