### PR TITLE
Add JabRef project (#268)

### DIFF
--- a/happycommits.json
+++ b/happycommits.json
@@ -119,6 +119,7 @@
     "johnsonandjohnson/openmrs-distro-cfl",
     "johnsonandjohnson/vxnaid",
     "JanssenProject/jans",
+    "JabRef/jabref",
     "kimetrica/MERON_api",
     "kobotoolbox/kpi",
     "kobotoolbox/kobocat",


### PR DESCRIPTION
**JabRef**:

- [x] Is a social good project.
 - Link: https://github.com/JabRef/jabref
- [x] The project has a contributing file.
- [x] The project has a code of conduct file.
- [x] The project has a license.
- [x] Actively maintained (last updated less than 1 months ago).

This related to this PR #269 and could close this issue (#268) .