### PR TITLE
RadioWave repo added in happycommits.json

### DIFF
--- a/happycommits.json
+++ b/happycommits.json
@@ -141,6 +141,7 @@
     "moodle/moodle",
     "nordic-institute/X-Road",
     "NMF-earth/nmf-app",
+    "OneDroid/RadioWave",
     "opencrvs/opencrvs-core",
     "openfisca/openfisca-core",
     "openforis/collect",


### PR DESCRIPTION
#### ℹ️ Repository information

**The repository**:

- [ ] Is a social good project.
 - Link: https://github.com/OneDroid/RadioWave
- [ ] Is for a DPG (Digital Public Good) 
- [ ] The project has tags in in its description denoting which SDGs it addresses. ie `sdg-1`, `sdg-2`, etc.
- [x] The project has a contributing file.
- [x] The project has a code of conduct file.
- [x] The project has a license.
- [x] Actively maintained (last updated less than 1 months ago).