### PR TITLE
Add Canadian Rental Data Sources

### DIFF
--- a/happycommits.json
+++ b/happycommits.json
@@ -83,6 +83,7 @@
     "farmOS/farmOS",
     "FASP-QAT/fasp-api",
     "FASP-QAT/fasp-core-ui",
+    "Fink692/canadian-rental-data-sources",
     "frappe/erpnext",
     "getodk/central",
     "getodk/collect",


### PR DESCRIPTION
Adds `Fink692/canadian-rental-data-sources` in lexicographic order.

The repository is an actively maintained, MIT-licensed civic-tech/open-data project supporting UN SDG 11 (Sustainable Cities and Communities). It has a detailed README, contributor instructions, a dependency-free Python validation workflow, and open contributor tasks labelled `good first issue` and `help wanted`.

Issues: https://github.com/Fink692/canadian-rental-data-sources/issues
Example good first issue: https://github.com/Fink692/canadian-rental-data-sources/issues/2

Disclosure: I maintain the submitted repository and also build BlockScore; the repository includes a clearly disclosed optional BlockScore early-access link.

Validation: `happycommits.json` parses as valid JSON. I could not run the full dependency install because the upstream `package-lock.json` currently resolves Next 16.2.6 while `package.json` requests 16.2.0; this change does not touch either file.