### PR TITLE
Add Empty state for zero search results in Repository and Organization Lists

### DIFF
--- a/components/EmptyState.tsx
+++ b/components/EmptyState.tsx
@@ -1,0 +1,12 @@
+import { faMagnifyingGlass } from "@fortawesome/free-solid-svg-icons"
+import { FontAwesomeIcon } from "@fortawesome/react-fontawesome"
+
+export const EmptyState = () => {
+    return (
+        <div className="flex flex-col items-center justify-center min-h-[50vh] p-4 w-full text-center">
+            <FontAwesomeIcon icon={faMagnifyingGlass} className="fa-magnifying-glass" />
+            <h2 className="text-xl font-semibold mb-2" >No results found</h2>
+            <p className="text-gray-500" >Try changing your search term or filters.</p>
+        </div>
+    )
+}

--- a/components/OrganizationList.tsx
+++ b/components/OrganizationList.tsx
@@ -8,6 +8,7 @@ import { LanguageFilter } from "./LanguageFilter";
 import { OrganizationItem } from "./OrganizationItem";
 import { Grid, Stack } from "@primer/react-brand";
 import { GeneralFilter } from "./GeneralFilter";
+import { EmptyState } from "./EmptyState";
 
 type OrganizationListProps = {
   organizations: Organization[];
@@ -72,9 +73,13 @@ export const OrganizationList = ({ organizations }: OrganizationListProps) => {
               hasMore={hasMoreItems}
               loader={<Loader />}
             >
-              {filteredOrganizations.slice(0, items).map((org) => (
-                <OrganizationItem key={org.id} organization={org} />
-              ))}
+              {filteredOrganizations.length > 0 ?
+                filteredOrganizations.slice(0, items).map((org) => (
+                  <OrganizationItem key={org.id} organization={org} />
+                ))
+                :
+                <EmptyState />
+              }
             </InfiniteScroll>
           </Grid.Column>
         </Grid>

--- a/components/RepositoryList.tsx
+++ b/components/RepositoryList.tsx
@@ -10,6 +10,7 @@ import { LanguageFilter } from "./LanguageFilter";
 import { RepositoryItem } from "./RepositoryItem";
 import { SDGFilter } from "./SDGFilter";
 import { Grid, Stack } from "@primer/react-brand";
+import { EmptyState } from "./EmptyState";
 
 type RepositoryListProps = {
   repositories: Repository[];
@@ -84,9 +85,13 @@ export const RepositoryList = ({ repositories, filter }: RepositoryListProps) =>
               hasMore={hasMoreItems}
               loader={<Loader />}
             >
-              {filteredRepositories.slice(0, items).map((repository) => (
-                <RepositoryItem key={repository.id} repository={repository} />
-              ))}
+              {filteredRepositories.length > 0 ?
+                filteredRepositories.slice(0, items).map((repository) => (
+                  <RepositoryItem key={repository.id} repository={repository} />
+                ))
+                :
+                <EmptyState />
+              }
             </InfiniteScroll>
           </Grid.Column>
         </Grid>


### PR DESCRIPTION
**Add empty state for zero search results in Repository and Organization List**
Fixes #550 
---

**Description**
This PR introduces a dedicated empty state UI for when search queries or applied filters yield zero results. Previously, when no repositories or organizations matched the search criteria, the UI did not provide clear feedback to the user.

**Changes Made**

- Created **EmptyState** component: Added a reusable empty state component.
- Updated **RepositoryList**: Used the EmptyState component to display empty state message in Individuals Tab.
- Updated **OrganizationList**: Used the EmptyState component to display empty state message in Teams Tab.

**Individuals Tab:**

<img width="1885" height="897" alt="image" src="https://github.com/user-attachments/assets/bca4d79f-1216-4870-b6be-d0280b52b2ac" />

**Teams Tab:**

<img width="1888" height="868" alt="image" src="https://github.com/user-attachments/assets/eb3178d6-aaff-462a-8c9c-a70907049880" />

