### PR TITLE
feat: add empty state for zero-results searches

### DIFF
--- a/components/OrganizationList.tsx
+++ b/components/OrganizationList.tsx
@@ -42,6 +42,41 @@ export const OrganizationList = ({ organizations }: OrganizationListProps) => {
   const loadMoreItems = () => setItems(items + itemsPerScroll);
   const hasMoreItems = items < filteredOrganizations.length;
 
+  if (filteredOrganizations.length === 0) {
+    return (
+      <main className="repoWrap">
+        <div className="grid-wrap">
+          <Grid>
+            <Grid.Column span={{ xsmall: 12, small: 12, medium: 12, large: 5, xlarge: 3 }}>
+              <Stack className="stack">
+                <div className="search-wrap">
+                  <GeneralFilter
+                    filter={filter}
+                    setFilter={
+                      setFilter as (filter: string | number | readonly string[] | undefined) => void
+                    }
+                  />
+                </div>
+                <LanguageFilter
+                  setSelectedLanguages={setSelectedLanguages}
+                  languageOptions={languageOptions}
+                />
+              </Stack>
+            </Grid.Column>
+            <Grid.Column
+              className="org-list-wrap"
+              span={{ xsmall: 12, small: 12, medium: 12, large: 7, xlarge: 9 }}
+            >
+              <div className="empty-state">
+                <p>No results found. Try changing your search term or filters.</p>
+              </div>
+            </Grid.Column>
+          </Grid>
+        </div>
+      </main>
+    );
+  }
+
   return (
     <main className="repoWrap">
       <div className="grid-wrap">

--- a/components/RepositoryList.tsx
+++ b/components/RepositoryList.tsx
@@ -61,6 +61,34 @@ export const RepositoryList = ({ repositories, filter }: RepositoryListProps) =>
   const loadMoreItems = () => setItems(items + itemsPerScroll);
   const hasMoreItems = items < filteredRepositories.length;
 
+  if (filteredRepositories.length === 0) {
+    return (
+      <main className="repoWrap">
+        <div className="grid-wrap">
+          <Grid>
+            <Grid.Column span={{ xsmall: 12, small: 12, medium: 12, large: 5, xlarge: 3 }}>
+              <Stack className="stack">
+                <LanguageFilter
+                  setSelectedLanguages={setSelectedLanguages}
+                  languageOptions={languageOptions}
+                />
+                <SDGFilter setSelectedTopics={setSelectedTopics} topicOptions={topicOptions} />
+              </Stack>
+            </Grid.Column>
+            <Grid.Column
+              className="repo-list-wrap"
+              span={{ xsmall: 12, small: 12, medium: 12, large: 7, xlarge: 9 }}
+            >
+              <div className="empty-state">
+                <p>No results found. Try changing your search term or filters.</p>
+              </div>
+            </Grid.Column>
+          </Grid>
+        </div>
+      </main>
+    );
+  }
+
   return (
     <main className="repoWrap">
       <div className="grid-wrap">

--- a/styles/globals.scss
+++ b/styles/globals.scss
@@ -322,3 +322,16 @@ base, html {
     pointer-events: none;
   }
 }
+
+.empty-state {
+  display: flex;
+  align-items: center;
+  justify-content: center;
+  padding: 48px 16px;
+  text-align: center;
+  color: var(--light-text-secondary, #57606A);
+  font-size: 16px;
+  border: 1px dashed var(--light-border, #B7BFC7);
+  border-radius: 6px;
+  background: var(--light-bg-primary, #FFF);
+}


### PR DESCRIPTION
## Summary
When search or filters return no matches, the results area is completely empty with no feedback to the user. This PR adds a clear empty state message.

## Changes
- { is a shell keyword — show empty state when no repos match
- { is a shell keyword — show empty state when no orgs match
-  — add  styling

## Test
- Apply a filter combination that yields zero results → see "No results found. Try changing your search term or filters."

Fixes #550