### PR TITLE
Add empty state for searches with no results

### DIFF
--- a/components/OrganizationList.tsx
+++ b/components/OrganizationList.tsx
@@ -41,6 +41,7 @@ export const OrganizationList = ({ organizations }: OrganizationListProps) => {
 
   const loadMoreItems = () => setItems(items + itemsPerScroll);
   const hasMoreItems = items < filteredOrganizations.length;
+  const isEmptyState = filteredOrganizations.length === 0;
 
   return (
     <main className="repoWrap">
@@ -66,16 +67,23 @@ export const OrganizationList = ({ organizations }: OrganizationListProps) => {
             className="org-list-wrap"
             span={{ xsmall: 12, small: 12, medium: 12, large: 7, xlarge: 9 }}
           >
-            <InfiniteScroll
-              dataLength={items}
-              next={loadMoreItems}
-              hasMore={hasMoreItems}
-              loader={<Loader />}
-            >
-              {filteredOrganizations.slice(0, items).map((org) => (
-                <OrganizationItem key={org.id} organization={org} />
-              ))}
-            </InfiniteScroll>
+            {isEmptyState ? (
+              <div className="p-6 rounded-md border border-slate-200 bg-white text-slate-700">
+                <p className="font-semibold">No results found.</p>
+                <p className="mt-2">Try changing your search term or filters.</p>
+              </div>
+            ) : (
+              <InfiniteScroll
+                dataLength={items}
+                next={loadMoreItems}
+                hasMore={hasMoreItems}
+                loader={<Loader />}
+              >
+                {filteredOrganizations.slice(0, items).map((org) => (
+                  <OrganizationItem key={org.id} organization={org} />
+                ))}
+              </InfiniteScroll>
+            )}
           </Grid.Column>
         </Grid>
       </div>

--- a/components/RepositoryList.tsx
+++ b/components/RepositoryList.tsx
@@ -60,6 +60,7 @@ export const RepositoryList = ({ repositories, filter }: RepositoryListProps) =>
 
   const loadMoreItems = () => setItems(items + itemsPerScroll);
   const hasMoreItems = items < filteredRepositories.length;
+  const isEmptyState = filteredRepositories.length === 0;
 
   return (
     <main className="repoWrap">
@@ -78,16 +79,23 @@ export const RepositoryList = ({ repositories, filter }: RepositoryListProps) =>
             className="repo-list-wrap"
             span={{ xsmall: 12, small: 12, medium: 12, large: 7, xlarge: 9 }}
           >
-            <InfiniteScroll
-              dataLength={items}
-              next={loadMoreItems}
-              hasMore={hasMoreItems}
-              loader={<Loader />}
-            >
-              {filteredRepositories.slice(0, items).map((repository) => (
-                <RepositoryItem key={repository.id} repository={repository} />
-              ))}
-            </InfiniteScroll>
+            {isEmptyState ? (
+              <div className="p-6 rounded-md border border-slate-200 bg-white text-slate-700">
+                <p className="font-semibold">No results found.</p>
+                <p className="mt-2">Try changing your search term or filters.</p>
+              </div>
+            ) : (
+              <InfiniteScroll
+                dataLength={items}
+                next={loadMoreItems}
+                hasMore={hasMoreItems}
+                loader={<Loader />}
+              >
+                {filteredRepositories.slice(0, items).map((repository) => (
+                  <RepositoryItem key={repository.id} repository={repository} />
+                ))}
+              </InfiniteScroll>
+            )}
           </Grid.Column>
         </Grid>
       </div>


### PR DESCRIPTION
Fixes #550\n\nShow a clear empty state in both filtered lists when no repositories or organizations match the current search or filters.