### PR TITLE
Add empty state for search results

### DIFF
--- a/components/OrganizationList.tsx
+++ b/components/OrganizationList.tsx
@@ -66,16 +66,22 @@ export const OrganizationList = ({ organizations }: OrganizationListProps) => {
             className="org-list-wrap"
             span={{ xsmall: 12, small: 12, medium: 12, large: 7, xlarge: 9 }}
           >
-            <InfiniteScroll
-              dataLength={items}
-              next={loadMoreItems}
-              hasMore={hasMoreItems}
-              loader={<Loader />}
-            >
-              {filteredOrganizations.slice(0, items).map((org) => (
-                <OrganizationItem key={org.id} organization={org} />
-              ))}
-            </InfiniteScroll>
+            {filteredOrganizations.length === 0 ? (
+              <div className="p-4 flex items-center justify-center">
+                <p>No results found. Try changing your search term or filters.</p>
+              </div>
+            ) : (
+              <InfiniteScroll
+                dataLength={items}
+                next={loadMoreItems}
+                hasMore={hasMoreItems}
+                loader={<Loader />}
+              >
+                {filteredOrganizations.slice(0, items).map((org) => (
+                  <OrganizationItem key={org.id} organization={org} />
+                ))}
+              </InfiniteScroll>
+            )}
           </Grid.Column>
         </Grid>
       </div>

--- a/components/RepositoryList.tsx
+++ b/components/RepositoryList.tsx
@@ -78,16 +78,22 @@ export const RepositoryList = ({ repositories, filter }: RepositoryListProps) =>
             className="repo-list-wrap"
             span={{ xsmall: 12, small: 12, medium: 12, large: 7, xlarge: 9 }}
           >
-            <InfiniteScroll
-              dataLength={items}
-              next={loadMoreItems}
-              hasMore={hasMoreItems}
-              loader={<Loader />}
-            >
-              {filteredRepositories.slice(0, items).map((repository) => (
-                <RepositoryItem key={repository.id} repository={repository} />
-              ))}
-            </InfiniteScroll>
+            {filteredRepositories.length === 0 ? (
+              <div className="p-4 flex items-center justify-center">
+                <p>No results found. Try changing your search term or filters.</p>
+              </div>
+            ) : (
+              <InfiniteScroll
+                dataLength={items}
+                next={loadMoreItems}
+                hasMore={hasMoreItems}
+                loader={<Loader />}
+              >
+                {filteredRepositories.slice(0, items).map((repository) => (
+                  <RepositoryItem key={repository.id} repository={repository} />
+                ))}
+              </InfiniteScroll>
+            )}
           </Grid.Column>
         </Grid>
       </div>


### PR DESCRIPTION
## Description

Adds an empty state when search or filter results contain no matches.

### Changes

- Added an empty state to the repository results view.
- Added an empty state to the organization results view.
- Displays a clear message when no results are found.
- Preserved the existing search, filtering, and infinite scroll behavior.

### Testing

- Tested the empty state on the Individuals page.
- Tested the empty state on the Teams page.
- Verified that normal results still appear after clearing the search/filter.
- ESLint passes successfully.

Fixes #550